### PR TITLE
Synth 2330

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ import (
 type MetricsAdapter struct {
 	basecmd.AdapterBase
 
-	// Message is printed on succesful startup
+	// Message is printed on successful startup
 	Message string
 }
 
@@ -77,7 +77,9 @@ func localMain() {
 	go ListAllExternalMetrics(prov)
 	for {
 		selector := labels.NewSelector()
-		valueList, err := prov.GetExternalMetric("default", selector, provider.ExternalMetricInfo{Metric: "com.dynatrace.builtin:pgi.jvm.garbagecollectioncount"})
+
+		valueList, err := prov.GetExternalMetric("default", selector,
+			provider.ExternalMetricInfo{Metric: "dsfm:synthetic.browser.engine_utilization:max:filter(eq(\"dt.entity.synthetic_location\", \"SYNTHETIC_LOCATION-7BA305221EFA8DBF\")):merge(\"location.name\", \"host.name\", \"dt.active_gate.working_mode\", \"dt.active_gate.id\"):last"})
 		if err != nil {
 			klog.Error("failed to query external metric", err.Error())
 		}

--- a/metrics/metric.go
+++ b/metrics/metric.go
@@ -59,5 +59,5 @@ type MetricV2 struct {
 	TSRequested      int64            `json:"-"`
 	ID               string           `json:"metricId"`
 	AggregationTypes AggregationTypes `json:"aggregationTypes"`
-	Dimesions        []DimensionV2    `json:"dimensionDefinitions"`
+	Dimensions        []DimensionV2    `json:"dimensionDefinitions"`
 }

--- a/metrics/metric.go
+++ b/metrics/metric.go
@@ -47,3 +47,17 @@ func (m *Metric) GetTSRequested() int64 {
 func (m *Metric) SetTSRequested(v int64) {
 	m.TSRequested = v
 }
+
+type DimensionV2 struct {
+	Key  string `json:"key"`
+	Name string `json:"displayName"`
+	Type string `json:"type"`
+}
+
+type MetricV2 struct {
+	TSQueried        int64            `json:"-"`
+	TSRequested      int64            `json:"-"`
+	ID               string           `json:"metricId"`
+	AggregationTypes AggregationTypes `json:"aggregationTypes"`
+	Dimesions        []DimensionV2    `json:"dimensionDefinitions"`
+}

--- a/metrics/quesry_result_v2.go
+++ b/metrics/quesry_result_v2.go
@@ -1,0 +1,16 @@
+package metrics
+
+type QueryResultV2 struct {
+	Result []QueryResultV2Details `json:"result"`
+}
+
+type QueryResultV2Details struct {
+	ID   string              `json:"metricId"`
+	Data []QueryResultV2Data `json:"data"`
+}
+
+type QueryResultV2Data struct {
+	DimensionsMap map[string]string `json:"dimensionMap"`
+	Timestamps    []int64           `json:"timestamps"`
+	Values        []float64         `json:"values"`
+}

--- a/topology/client.go
+++ b/topology/client.go
@@ -37,7 +37,7 @@ func (tc *Client) GetMetrics() ([]cache.Item, error) {
 }
 
 func isAPIv1(id string) bool {
-	return strings.HasPrefix(id, "v1:") || strings.HasPrefix(id, "dynatrace.com.builtin:")
+	return strings.HasPrefix(id, "v1:") || strings.HasPrefix(id, "com.dynatrace.builtin:") || strings.HasPrefix(id, "custom")
 }
 
 func (tc *Client) getMetricAPIv1(id string) (cache.Item, error) {
@@ -72,7 +72,7 @@ func (tc *Client) getMetricAPIv2(metricId string) (cache.Item, error) {
 
 	metric.ID = metricV2.ID
 	metric.Dimensions = []string{}
-	for _, dim := range metricV2.Dimesions {
+	for _, dim := range metricV2.Dimensions {
 		metric.Dimensions = append(metric.Dimensions, dim.Key)
 	}
 	metric.AggregationTypes = metricV2.AggregationTypes

--- a/topology/client.go
+++ b/topology/client.go
@@ -189,8 +189,10 @@ func (tc *Client) getDataPointsAPIv2(metricID string, aggregationType *metrics.A
 
 		dataPoints = append(dataPoints, &dataPoint)
 	}
-	key := resultV2.Result[0].Data[0].DimensionsMap["location.name"]
-	result.DataResult.DataPoints[key] = dataPoints
+
+	for _, value := range resultV2.Result[0].Data[0].DimensionsMap {
+		result.DataResult.DataPoints[value] = dataPoints
+	}
 
 	return &result, nil
 }

--- a/topology/client.go
+++ b/topology/client.go
@@ -3,6 +3,7 @@ package topology
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/dtcookie/k8s-dynatrace-metrics-adapter/cache"
@@ -35,12 +36,14 @@ func (tc *Client) GetMetrics() ([]cache.Item, error) {
 	return result, nil
 }
 
-func (tc *Client) GetMetric(id string, options map[string]interface{}) (cache.Item, error) {
-	if strings.Contains(id, ":#") {
-		return nil, nil
-	}
+func isAPIv1(id string) bool {
+	return strings.HasPrefix(id, "v1:") || strings.HasPrefix(id, "dynatrace.com.builtin:")
+}
+
+func (tc *Client) getMetricAPIv1(id string) (cache.Item, error) {
 	var err error
 	var data []byte
+
 	if data, err = tc.restClient.GET(fmt.Sprintf("/api/v1/timeseries/%s?includeData=false", id), 200); err != nil {
 		return nil, err
 	}
@@ -48,7 +51,45 @@ func (tc *Client) GetMetric(id string, options map[string]interface{}) (cache.It
 	if err := json.Unmarshal(data, &metric); err != nil {
 		return nil, err
 	}
+
 	return &metric, nil
+}
+
+func (tc *Client) getMetricAPIv2(metricId string) (cache.Item, error) {
+	var err error
+	var data []byte
+
+	if data, err = tc.restClient.GET(fmt.Sprintf("/api/v2/metrics/%s", metricId), 200); err != nil {
+		return nil, err
+	}
+
+	var metric metrics.Metric
+	var metricV2 metrics.MetricV2
+
+	if err := json.Unmarshal(data, &metricV2); err != nil {
+		return nil, err
+	}
+
+	metric.ID = metricV2.ID
+	metric.Dimensions = []string{}
+	for _, dim := range metricV2.Dimesions {
+		metric.Dimensions = append(metric.Dimensions, dim.Key)
+	}
+	metric.AggregationTypes = metricV2.AggregationTypes
+
+	return &metric, nil
+}
+
+func (tc *Client) GetMetric(id string, options map[string]interface{}) (cache.Item, error) {
+	if strings.Contains(id, ":#") {
+		return nil, nil
+	}
+
+	if isAPIv1(id) {
+		return tc.getMetricAPIv1(id)
+	}
+
+	return tc.getMetricAPIv2(id)
 }
 
 type MetricList struct {
@@ -74,18 +115,12 @@ func (tc *Client) GetAllMetrics(fakeID string, options map[string]interface{}) (
 
 func Hide(v interface{}) {}
 
-func (tc *Client) GetDataPoints(timeseriesID string, options map[string]interface{}) (cache.Item, error) {
-	var aggregationType *metrics.AggregationType
-	var tags map[string]*string
-	if options != nil {
-		if v, found := options["agg"]; found {
-			agg := v.(metrics.AggregationType)
-			aggregationType = &agg
-		}
-		if v, found := options["tags"]; found {
-			tags = v.(map[string]*string)
-		}
-	}
+func (tc *Client) getDataPointsAPIv1(
+	timeseriesID string,
+	aggregationType *metrics.AggregationType,
+	tags map[string]*string,
+) (cache.Item, error) {
+
 	var err error
 	var data []byte
 	var url string
@@ -111,6 +146,74 @@ func (tc *Client) GetDataPoints(timeseriesID string, options map[string]interfac
 		return nil, err
 	}
 	return &result, nil
+}
+
+func (tc *Client) getDataPointsAPIv2(metricID string, aggregationType *metrics.AggregationType) (cache.Item, error) {
+
+	var err error
+	var data []byte
+	var path = fmt.Sprintf("/api/v2/metrics/query?metricSelector=%s", url.QueryEscape(metricID))
+
+	// time range and resolution
+	path = fmt.Sprintf("%v&resolution=m&from=now-5m&to=now", path)
+
+	if data, err = tc.restClient.GET(path, 200); err != nil {
+		return nil, err
+	}
+	result := metrics.QueryResult{}
+	resultV2 := metrics.QueryResultV2{}
+
+	if err := json.Unmarshal(data, &resultV2); err != nil {
+		return nil, err
+	}
+
+	if len(resultV2.Result) == 0 || len(resultV2.Result[0].Data) == 0 {
+		return nil, nil
+	}
+
+	result.TimeseriesID = resultV2.Result[0].ID
+	result.DataResult = &metrics.DataResult{}
+	result.DataResult.TimeseriesID = resultV2.Result[0].ID
+	result.DataResult.AggregationType = aggregationType
+	result.DataResult.Entities = resultV2.Result[0].Data[0].DimensionsMap
+	result.DataResult.DataPoints = map[string]metrics.DataPoints{}
+
+	dataPoints := metrics.DataPoints{}
+	for index, timestamp := range resultV2.Result[0].Data[0].Timestamps {
+		value := resultV2.Result[0].Data[0].Values[index]
+
+		dataPoint := metrics.DataPoint{
+			TimeStamp: timestamp,
+			Value:     &value,
+		}
+
+		dataPoints = append(dataPoints, &dataPoint)
+	}
+	key := resultV2.Result[0].Data[0].DimensionsMap["location.name"]
+	result.DataResult.DataPoints[key] = dataPoints
+
+	return &result, nil
+}
+
+func (tc *Client) GetDataPoints(timeseriesID string, options map[string]interface{}) (cache.Item, error) {
+	var aggregationType *metrics.AggregationType
+	var tags map[string]*string
+
+	if options != nil {
+		if v, found := options["agg"]; found {
+			agg := v.(metrics.AggregationType)
+			aggregationType = &agg
+		}
+		if v, found := options["tags"]; found {
+			tags = v.(map[string]*string)
+		}
+	}
+
+	if isAPIv1(timeseriesID) {
+		return tc.getDataPointsAPIv1(timeseriesID, aggregationType, tags)
+	}
+
+	return tc.getDataPointsAPIv2(timeseriesID, aggregationType)
 }
 
 func (tc *Client) GetService(id string, options map[string]interface{}) (cache.Item, error) {


### PR DESCRIPTION
Added support for REST API v2 metrics, we assume that v1 metrics start with one of the prefixes:
* v1:
* com.dynatrace.builtin:
* custom

After metadata and/or timeseries are retrieved from v2 endpoints, data is normalized to v1 format (data structures) and processing goes the old path.