### PR TITLE
Updating HorizontalPodAutoscaler to autoscaling/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A prebuilt version of this project already is available on [Docker Hub](https://
 This is an example for a Horizontal Pod Scaler scaling `frontend-http-server` based on the metric `com.dynatrace.builtin:service.responsetime`, expecting the average response time of the monitored service to not increase 1.5 seconds.
 
 ```
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: frontend-http-server

--- a/sample/hpa.yaml
+++ b/sample/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: frontend-http-server


### PR DESCRIPTION

Since k8s 1.23 autoscaling/v2beta2 is depecated

HorizontalPodAutoscaler is now in autoscaling/v2 and not autoscaling/v2beta
